### PR TITLE
Removed duplicates in nav_graph.xml

### DIFF
--- a/UI/app/src/main/res/navigation/nav_graph.xml
+++ b/UI/app/src/main/res/navigation/nav_graph.xml
@@ -25,24 +25,4 @@
             android:id="@+id/action_SecondFragment_to_FirstFragment"
             app:destination="@id/FirstFragment" />
     </fragment>
-    <fragment
-        android:id="@+id/FirstFragment"
-        android:name="com.example.pathfinder.FirstFragment"
-        android:label="@string/first_fragment_label"
-        tools:layout="@layout/fragment_first">
-
-        <action
-            android:id="@+id/action_FirstFragment_to_SecondFragment"
-            app:destination="@id/SecondFragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/SecondFragment"
-        android:name="com.example.pathfinder.SecondFragment"
-        android:label="@string/second_fragment_label"
-        tools:layout="@layout/fragment_second">
-
-        <action
-            android:id="@+id/action_SecondFragment_to_FirstFragment"
-            app:destination="@id/FirstFragment" />
-    </fragment>
 </navigation>


### PR DESCRIPTION
### Correction of a bug CI pointed at in nav_graph.xml

***
Errors found:

  /home/runner/work/group-07/group-07/UI/app/src/main/res/navigation/nav_graph.xml:29: Error: Duplicate id @+id/FirstFragment, already defined earlier in this layout [DuplicateIds]
          android:id="@+id/FirstFragment"

***
Resolves #29 