### PR TITLE
Passenger screen

### DIFF
--- a/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
@@ -3,6 +3,7 @@ package com.example.pathfinder.Activities;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -44,15 +45,15 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
     private static final int IMAGE_WIDTH = 320;
     private static final int IMAGE_HEIGHT = 240;
 
+    //key names for stored data in shared preferences
+    private static final String KEY_STOP = "stop";
+    private static final String KEY_HANDICAP = "handicap";
+
     private MqttClient mMqttClient;
-    //Park/ lock
-    //private boolean isParked = false;
-    //Engine activity
-    //private boolean isActive = false;
     private boolean isConnected = false;
-    private ImageView mVideoStream, mSignOutBtn;
+    private ImageView mVideoStream, mSignOutBtn, mAccessibilityRequest;
     private TextView mSpeedLog, mDistanceLog;
-    private TextView textView;
+    private TextView textView, mStopRequest;
     private SeekBar seekBar;
     private ToggleButton mCruiseControlBtn, mParkBtn;
 
@@ -71,6 +72,8 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
         mSpeedLog = findViewById(R.id.speed_log) ;
         mDistanceLog = findViewById(R.id.distance_log);
         mSignOutBtn = findViewById(R.id.sign_out);
+        mStopRequest = findViewById(R.id.stop);
+        mAccessibilityRequest = findViewById(R.id.accessibility);
 
         mMqttClient = new MqttClient(getApplicationContext(), MQTT_SERVER, TAG);
 
@@ -79,6 +82,10 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
         textView = (TextView) findViewById(R.id.textView);
         seekBar = (SeekBar) findViewById(R.id.seekBar);
 
+        //checks the state of stop request
+        checkStopRequest();
+        //checks the state of accessibility request
+        checkAccessibilityRequest();
         connectToMqttBroker();
 
         //sign out button that redirects user back to DriverLogin activity
@@ -180,8 +187,12 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
                     Toast.makeText(getApplicationContext(), connectionLost, Toast.LENGTH_SHORT).show();
                 }
 
-                //The topics shall be catch hold of by this method and handled through the statements for the specific functions.
-                // (If a message published to a specific topic, use that message to the some specific function).
+                /*
+                * The topics shall be catch hold of by this method and handled through the
+                * statements for the specific functions.
+                * If a message published to a specific topic, use that message to the some
+                * ( specific function).
+                */
                 @Override
                 public void messageArrived(String topic, MqttMessage message) throws Exception {
                     if (topic.equals("/smartcar/camera")) {
@@ -225,23 +236,45 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
         }
     }
 
+    /*
+     * helper method to check if stop request evaluates as true.
+     * if stop request has is true then the stop status lights up and is made visible; otherwise
+     * its color is set to white to appear invisible.
+     */
+
+    public void checkStopRequest() {
+        sharedPreferences = getSharedPreferences(KEY_STOP, Context.MODE_PRIVATE);
+
+        if (sharedPreferences.getBoolean(KEY_STOP, true)) {
+            mStopRequest.setBackgroundColor(Color.parseColor("#B33701"));
+        } else {
+            mStopRequest.setBackgroundColor(Color.WHITE);
+        }
+    }
+
+    /*
+     * helper method to check if accessibility request evaluated as true.
+     * if accessibility request has is true then the stop status and accessibility symbols
+     * light up and is made visible; otherwise their colors are set to white to appear invisible.
+     */
+
+    public void checkAccessibilityRequest() {
+        sharedPreferences = getSharedPreferences(KEY_HANDICAP, Context.MODE_PRIVATE);
+
+        if (sharedPreferences.getBoolean(KEY_HANDICAP, true)) {
+            mStopRequest.setBackgroundColor(Color.parseColor("#B33701"));
+            mAccessibilityRequest.setColorFilter(Color.parseColor("#008080"));
+        } else {
+            mStopRequest.setBackgroundColor(Color.WHITE);
+            mAccessibilityRequest.setColorFilter(Color.WHITE);
+        }
+    }
+
     void drive(int throttleSpeed, int steeringAngle, String actionDescription) {
         notConnected();
         Log.i(TAG, actionDescription);
-        if(throttleSpeed > speed + 5 || throttleSpeed < speed - 5 || throttleSpeed == 0){
-            speed = throttleSpeed;
-            mMqttClient.publish(THROTTLE_CONTROL, Integer.toString(throttleSpeed), QOS, null);
-        }
-        if(steeringAngle > 10 && angle <= 0){
-            angle = 30;
-            mMqttClient.publish(STEERING_CONTROL, Integer.toString(angle), QOS, null);
-        }else if(steeringAngle < -10 && angle >= 0){
-            angle = -30;
-            mMqttClient.publish(STEERING_CONTROL, Integer.toString(angle), QOS, null);
-        }else if (steeringAngle <= 10 && steeringAngle >= -10 && angle != 0){
-            angle = 0;
-            mMqttClient.publish(STEERING_CONTROL, Integer.toString(angle), QOS, null);
-        }
+        mMqttClient.publish(THROTTLE_CONTROL, Integer.toString(throttleSpeed), QOS, null);
+        mMqttClient.publish(STEERING_CONTROL, Integer.toString(steeringAngle), QOS, null);
         speedLog(Math.abs(throttleSpeed));
     }
 
@@ -255,7 +288,10 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
         mSpeedLog.setText(String.valueOf(speed) + " km/h");
     }
 
-    // A helper method takes the distance value from ODOMETER_LOG(topic="/smartcar/odometer") and set it to distance log on the related layout in the UI.
+    /*
+    * A helper method takes the distance value from ODOMETER_LOG(topic="/smartcar/odometer") and
+    * set it to distance log on the related layout in the UI.
+    */
     void distanceLog(double distance) {
         distance = distance/100;
         notConnected();
@@ -266,7 +302,6 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
     public void brakeBtn(View view) {
         brake();
     }
-
 
     public void nextStopBtn(View view) {
 

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
@@ -52,8 +52,7 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
     private MqttClient mMqttClient;
     private boolean isConnected = false;
     private ImageView mVideoStream, mSignOutBtn, mAccessibilityRequest;
-    private TextView mSpeedLog, mDistanceLog;
-    private TextView textView, mStopRequest;
+    private TextView mSpeedLog, mDistanceLog, mStopRequest, textView;
     private SeekBar seekBar;
     private ToggleButton mCruiseControlBtn, mParkBtn;
 

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
@@ -245,7 +245,7 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
     public void checkStopRequest() {
         sharedPreferences = getSharedPreferences(KEY_STOP, Context.MODE_PRIVATE);
 
-        if (sharedPreferences.getBoolean(KEY_STOP, true)) {
+        if (sharedPreferences.getBoolean(KEY_STOP, false)) {
             mStopRequest.setBackgroundColor(Color.parseColor("#B33701"));
         } else {
             mStopRequest.setBackgroundColor(Color.WHITE);
@@ -261,11 +261,9 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
     public void checkAccessibilityRequest() {
         sharedPreferences = getSharedPreferences(KEY_HANDICAP, Context.MODE_PRIVATE);
 
-        if (sharedPreferences.getBoolean(KEY_HANDICAP, true)) {
-            mStopRequest.setBackgroundColor(Color.parseColor("#B33701"));
+        if (sharedPreferences.getBoolean(KEY_HANDICAP, false)) {
             mAccessibilityRequest.setColorFilter(Color.parseColor("#008080"));
         } else {
-            mStopRequest.setBackgroundColor(Color.WHITE);
             mAccessibilityRequest.setColorFilter(Color.WHITE);
         }
     }

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/ModeType.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/ModeType.java
@@ -1,6 +1,0 @@
-package com.example.pathfinder.Activities;
-
-public enum ModeType {
-    PARK,
-    DRIVE
-}

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
@@ -48,19 +48,15 @@ public class PassengerDashboard extends AppCompatActivity {
         mStopStatus = findViewById(R.id.stop_status);
         mAccessibility = (ImageView) findViewById(R.id.accessibility);
 
+        /*
+         * first checks whether stop and/or accessibility request were made and stored into
+         * shared preferences
+         */
+
         mStopBtn.setChecked(update(KEY_STOP));
         mHandicapBtn.setChecked(update(KEY_HANDICAP));
 
-        /*
-        * first checks whether stop and/or accessibility request were made and stored into
-        * shared preferences
-        */
-        saveIntoSharedPrefs(SHARED_PREF_NAME, false);
 
-        //checks the state of stop request
-        getStopRequest();
-        //checks the state of accessibility request
-        getAccessibilityRequest();
 
         mStopBtn.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
@@ -70,7 +66,6 @@ public class PassengerDashboard extends AppCompatActivity {
                     //data is stored to shared preference
                     saveIntoSharedPrefs(KEY_STOP, true);
                     passengerSharedPrefs(KEY_STOP, true);
-
                     /*
                      * images are given a red and teal background colors respectively to make them
                      * visible when someone presses the handicap accessibility button
@@ -97,6 +92,7 @@ public class PassengerDashboard extends AppCompatActivity {
                 //if the button is toggled to true
                 if (isChecked) {
                     //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_STOP, true);
                     saveIntoSharedPrefs(KEY_HANDICAP, true);
                     passengerSharedPrefs(KEY_HANDICAP, true);
 
@@ -109,6 +105,7 @@ public class PassengerDashboard extends AppCompatActivity {
                     Log.d(KEY_HANDICAP, "this is on");
                 } else {
                     //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_STOP, false);
                     saveIntoSharedPrefs(KEY_HANDICAP, false);
                     passengerSharedPrefs(KEY_HANDICAP, false);
                     /*
@@ -141,10 +138,12 @@ public class PassengerDashboard extends AppCompatActivity {
     public void getStopRequest() {
         sharedPreferences = getSharedPreferences(KEY_STOP, Context.MODE_PRIVATE);
 
-        if (sharedPreferences.getBoolean(KEY_STOP, true)) {
+        if (sharedPreferences.getBoolean(KEY_STOP, false)) {
             mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
+            Log.d(KEY_STOP, "red");
         } else {
             mStopStatus.setBackgroundColor(Color.WHITE);
+            Log.d(KEY_STOP, "white");
         }
     }
 
@@ -156,12 +155,12 @@ public class PassengerDashboard extends AppCompatActivity {
     public void getAccessibilityRequest() {
         sharedPreferences = getSharedPreferences(KEY_HANDICAP, Context.MODE_PRIVATE);
 
-        if (sharedPreferences.getBoolean(KEY_HANDICAP, true)) {
-            mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
+        if (sharedPreferences.getBoolean(KEY_HANDICAP, false)) {
             mAccessibility.setColorFilter(Color.parseColor("#008080"));
+            Log.d(KEY_HANDICAP, "red");
         } else {
-            mStopStatus.setBackgroundColor(Color.WHITE);
             mAccessibility.setColorFilter(Color.WHITE);
+            Log.d(KEY_HANDICAP, "white");
         }
     }
 
@@ -180,7 +179,7 @@ public class PassengerDashboard extends AppCompatActivity {
     * Helper method to save state of buttons into a shared preference
     */
     public void saveIntoSharedPrefs(String key, Boolean value) {
-        sharedPreferences = getSharedPreferences(key, Context.MODE_PRIVATE);
+        sharedPreferences = getApplicationContext().getSharedPreferences(key, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean(key, value);
         editor.apply();
@@ -192,6 +191,16 @@ public class PassengerDashboard extends AppCompatActivity {
     public boolean update(String key) {
         sharedPreferences = getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
         return sharedPreferences.getBoolean(key, false);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        //checks the state of stop request
+        getStopRequest();
+        //checks the state of accessibility request
+        getAccessibilityRequest();
     }
 
 }

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
@@ -63,22 +63,22 @@ public class PassengerDashboard extends AppCompatActivity {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 //if the button is toggled to true
                 if (isChecked) {
-                    //data is stored to shared preference
+                    //boolean data is stored to shared preference
                     saveIntoSharedPrefs(KEY_STOP, true);
                     passengerSharedPrefs(KEY_STOP, true);
                     /*
-                     * images are given a red and teal background colors respectively to make them
-                     * visible when someone presses the handicap accessibility button
+                     * text is given a red background color to make it visible when someone
+                     * toggles on the stop button
                      */
                     mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
                     Log.d(KEY_STOP, "this is on");
                 } else {
-                    //data is stored to shared preference
+                    //boolean data is stored to shared preference
                     saveIntoSharedPrefs(KEY_STOP, false);
                     passengerSharedPrefs(KEY_STOP, false);
                     /*
-                     * images are given a white background color to make them
-                     * visible when someone presses the handicap accessibility button
+                     * text is given a white background color to make it visible when someone
+                     * toggles on the stop button
                      */
                     mStopStatus.setBackgroundColor(Color.WHITE);
                     Log.d(KEY_STOP, "this is off");
@@ -91,26 +91,26 @@ public class PassengerDashboard extends AppCompatActivity {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 //if the button is toggled to true
                 if (isChecked) {
-                    //data is stored to shared preference
+                    //boolean data is stored to shared preference
                     saveIntoSharedPrefs(KEY_STOP, true);
                     saveIntoSharedPrefs(KEY_HANDICAP, true);
                     passengerSharedPrefs(KEY_HANDICAP, true);
 
                     /*
                      * images are given a red and teal background colors respectively to make them
-                     * visible when someone presses the handicap accessibility button
+                     * visible when someone toggles on the handicap accessibility button
                      */
                     mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
                     mAccessibility.setColorFilter(Color.parseColor("#008080"));
                     Log.d(KEY_HANDICAP, "this is on");
                 } else {
-                    //data is stored to shared preference
+                    //boolean data is stored to shared preference
                     saveIntoSharedPrefs(KEY_STOP, false);
                     saveIntoSharedPrefs(KEY_HANDICAP, false);
                     passengerSharedPrefs(KEY_HANDICAP, false);
                     /*
                      * images are given a white background color to make them
-                     * visible when someone presses the handicap accessibility button
+                     * visible when someone toggles off the handicap accessibility button
                      */
                     mStopStatus.setBackgroundColor(Color.WHITE);
                     mAccessibility.setColorFilter(Color.WHITE);

--- a/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/PassengerDashboard.java
@@ -2,12 +2,14 @@ package com.example.pathfinder.Activities;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.media.Image;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CompoundButton;
@@ -46,62 +48,77 @@ public class PassengerDashboard extends AppCompatActivity {
         mStopStatus = findViewById(R.id.stop_status);
         mAccessibility = (ImageView) findViewById(R.id.accessibility);
 
-        sharedPreferences = getSharedPreferences(SHARED_PREF_NAME, MODE_PRIVATE);
+        mStopBtn.setChecked(update(KEY_STOP));
+        mHandicapBtn.setChecked(update(KEY_HANDICAP));
 
-        //checks if shared pref data is available
-        String stopStatus = sharedPreferences.getString(KEY_STOP, null);
+        /*
+        * first checks whether stop and/or accessibility request were made and stored into
+        * shared preferences
+        */
+        saveIntoSharedPrefs(SHARED_PREF_NAME, false);
 
-        if (stopStatus == mStopBtn.getTextOff().toString()) {
-            Intent intent = new Intent(PassengerDashboard.this, DriverDashboard.class);
-        }
+        //checks the state of stop request
+        getStopRequest();
+        //checks the state of accessibility request
+        getAccessibilityRequest();
 
         mStopBtn.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                //toggle enabled
+                //if the button is toggled to true
                 if (isChecked) {
-                    //puts data on shared pref
-                    SharedPreferences.Editor editor = sharedPreferences.edit();
-                    editor.putString(KEY_HANDICAP, mStopBtn.getTextOn().toString());
-                    editor.putString(KEY_HANDICAP, mHandicapBtn.getTextOn().toString());
-                    editor.apply();
+                    //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_STOP, true);
+                    passengerSharedPrefs(KEY_STOP, true);
 
-                    //pass above data to DriverDashboard
-                    Intent intent = new Intent(PassengerDashboard.this, DriverDashboard.class);
-
-                    //stop requested
+                    /*
+                     * images are given a red and teal background colors respectively to make them
+                     * visible when someone presses the handicap accessibility button
+                     */
                     mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
+                    Log.d(KEY_STOP, "this is on");
                 } else {
-                    //toggle disabled
+                    //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_STOP, false);
+                    passengerSharedPrefs(KEY_STOP, false);
+                    /*
+                     * images are given a white background color to make them
+                     * visible when someone presses the handicap accessibility button
+                     */
                     mStopStatus.setBackgroundColor(Color.WHITE);
-                    mAccessibility.setColorFilter(Color.WHITE);
+                    Log.d(KEY_STOP, "this is off");
                 }
-
             }
         });
 
         mHandicapBtn.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                //if the button is toggled to true
                 if (isChecked) {
-                    //puts data on shared pref
-                    SharedPreferences.Editor editor = sharedPreferences.edit();
-                    editor.putString(KEY_HANDICAP, mStopBtn.getTextOn().toString());
-                    editor.putString(KEY_HANDICAP, mHandicapBtn.getTextOn().toString());
-                    editor.apply();
+                    //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_HANDICAP, true);
+                    passengerSharedPrefs(KEY_HANDICAP, true);
 
-                    //pass above data to DriverDashboard
-                    Intent intent = new Intent(PassengerDashboard.this, DriverDashboard.class);
-
-                    //stop requested
+                    /*
+                     * images are given a red and teal background colors respectively to make them
+                     * visible when someone presses the handicap accessibility button
+                     */
                     mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
                     mAccessibility.setColorFilter(Color.parseColor("#008080"));
+                    Log.d(KEY_HANDICAP, "this is on");
                 } else {
-                    //toggle disabled
+                    //data is stored to shared preference
+                    saveIntoSharedPrefs(KEY_HANDICAP, false);
+                    passengerSharedPrefs(KEY_HANDICAP, false);
+                    /*
+                     * images are given a white background color to make them
+                     * visible when someone presses the handicap accessibility button
+                     */
                     mStopStatus.setBackgroundColor(Color.WHITE);
                     mAccessibility.setColorFilter(Color.WHITE);
+                    Log.d(KEY_HANDICAP, "this is off");
                 }
-
             }
         });
 
@@ -114,6 +131,67 @@ public class PassengerDashboard extends AppCompatActivity {
         });
 
 
+    }
+
+    /*
+     * helper method to check if stop request evaluates as true.
+     * if stop request has is true then the stop status lights up and is made visible; otherwise
+     * its color is set to white to appear invisible.
+     */
+    public void getStopRequest() {
+        sharedPreferences = getSharedPreferences(KEY_STOP, Context.MODE_PRIVATE);
+
+        if (sharedPreferences.getBoolean(KEY_STOP, true)) {
+            mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
+        } else {
+            mStopStatus.setBackgroundColor(Color.WHITE);
+        }
+    }
+
+    /*
+    * helper method to check if accessibility request evaluates as true.
+    * if accessibility request has is true then the stop status and accessibility symbols
+    * light up and is made visible; otherwise their colors are set to white to appear invisible.
+    */
+    public void getAccessibilityRequest() {
+        sharedPreferences = getSharedPreferences(KEY_HANDICAP, Context.MODE_PRIVATE);
+
+        if (sharedPreferences.getBoolean(KEY_HANDICAP, true)) {
+            mStopStatus.setBackgroundColor(Color.parseColor("#B33701"));
+            mAccessibility.setColorFilter(Color.parseColor("#008080"));
+        } else {
+            mStopStatus.setBackgroundColor(Color.WHITE);
+            mAccessibility.setColorFilter(Color.WHITE);
+        }
+    }
+
+    /*
+    * Helper method to save state of buttons into passenger shared preference
+    *
+    * */
+    public void passengerSharedPrefs(String key, Boolean value) {
+        sharedPreferences = getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(key, value);
+        editor.commit();
+    }
+
+    /*
+    * Helper method to save state of buttons into a shared preference
+    */
+    public void saveIntoSharedPrefs(String key, Boolean value) {
+        sharedPreferences = getSharedPreferences(key, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(key, value);
+        editor.apply();
+    }
+
+    /*
+    * Helper update to last state of buttons into a shared preference
+    */
+    public boolean update(String key) {
+        sharedPreferences = getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE);
+        return sharedPreferences.getBoolean(key, false);
     }
 
 }

--- a/UI/app/src/main/res/layout/activity_driver_dashboard.xml
+++ b/UI/app/src/main/res/layout/activity_driver_dashboard.xml
@@ -336,15 +336,16 @@
                         android:layout_centerHorizontal="true"/>
 
                 </RelativeLayout>
-
             </LinearLayout>
-
         </RelativeLayout>
 
         <com.example.pathfinder.Activities.ThumbstickView
             android:id="@+id/testThumbstick"
             android:layout_width="match_parent"
-            android:layout_height="300dp" />
+            android:layout_height="250dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
     </LinearLayout>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/UI/app/src/main/res/layout/activity_driver_dashboard.xml
+++ b/UI/app/src/main/res/layout/activity_driver_dashboard.xml
@@ -342,7 +342,7 @@
         <com.example.pathfinder.Activities.ThumbstickView
             android:id="@+id/testThumbstick"
             android:layout_width="match_parent"
-            android:layout_height="250dp"
+            android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/UI/app/src/main/res/layout/activity_driver_dashboard.xml
+++ b/UI/app/src/main/res/layout/activity_driver_dashboard.xml
@@ -99,19 +99,30 @@
                 <RelativeLayout
                     android:layout_width="110dp"
                     android:layout_height="85dp"
-                    android:background="@drawable/card_1"
                     android:layout_marginLeft="5dp"
                     android:layout_marginRight="5dp"
                     android:layout_marginTop="2dp"
                     >
+                    <ImageView
+                        android:id="@+id/accessibility"
+                        android:layout_width="35dp"
+                        android:layout_height="35dp"
+                        android:layout_marginTop="10dp"
+                        android:layout_centerHorizontal="true"
+                        android:src="@drawable/img_handicap"
+                        app:tint="@color/white" />
+
                     <TextView
-                        android:layout_width="wrap_content"
+                        android:id="@+id/stop"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/basic"
-                        android:textSize="16dp"
+                        android:textSize="18dp"
                         android:text="@string/stop_requested"
-                        android:textColor="@color/yellow"
-                        android:layout_marginTop="20dp"
+                        android:textAllCaps="true"
+                        android:textColor="@color/white"
+                        android:background="@color/white"
+                        android:layout_marginTop="55dp"
                         android:layout_marginLeft="3dp"
                         android:layout_marginRight="3dp"
                         android:gravity="center"/>

--- a/UI/app/src/main/res/layout/activity_driver_dashboard.xml
+++ b/UI/app/src/main/res/layout/activity_driver_dashboard.xml
@@ -18,12 +18,6 @@
             android:layout_height="wrap_content"
             android:padding="20dp">
 
-            <ImageView
-                android:layout_width="30dp"
-                android:layout_height="30dp"
-                android:src="@drawable/img_menu"
-                android:id="@+id/nav"
-                android:layout_centerVertical="true"/>
 
             <TextView
                 android:layout_width="wrap_content"

--- a/UI/app/src/main/res/layout/activity_passenger_dashboard.xml
+++ b/UI/app/src/main/res/layout/activity_passenger_dashboard.xml
@@ -69,7 +69,7 @@
                 android:text="@string/stop_requested"
                 android:textColor="@color/white"
                 android:layout_marginTop="20dp"
-                android:layout_marginLeft="17dp"
+                android:layout_marginLeft="56dp"
                 android:gravity="center"
                 android:textAllCaps="true"/>
         </RelativeLayout>

--- a/UI/app/src/main/res/values/colors.xml
+++ b/UI/app/src/main/res/values/colors.xml
@@ -9,5 +9,7 @@
     <color name="white">#FFFFFFFF</color>
     <color name="yellow">#FEA600</color>
     <color name="purple">#54418F</color>
+    <color name="teal">#008080</color>
     <color name="gray">#877C7C</color>
+    <color name="red">#B33701</color>
 </resources>

--- a/UI/app/src/main/res/values/strings.xml
+++ b/UI/app/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
     <string name="distance">Distance</string>
     <string name="speed_log">0 km/h</string>
     <string name="distance_log">0 m</string>
-    <string name="stop_requested">Stop Requested</string>
+    <string name="stop_requested">Stop</string>
     <string name="signIn_failed">"Error: invalid username or password."</string>
 
     <!-- About -->

--- a/UI/app/src/main/res/values/strings.xml
+++ b/UI/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="speed_log">0 km/h</string>
     <string name="distance_log">0 m</string>
     <string name="stop_requested">Stop Requested</string>
+    <string name="signIn_failed">"Error: invalid username or password."</string>
 
     <!-- About -->
     <string name="about">About</string>

--- a/UI/app/src/main/res/values/strings.xml
+++ b/UI/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="welcome">Hello there, welcome back!</string>
     <string name="message">Sign In to continue</string>
     <string name="sign_in">Sign In</string>
-    <string name="passenger">Not a driver? Get started now.</string>
+    <string name="passenger">Are you a passenger? Get started now.</string>
 
     <!-- Driver Dashboard -->
     <string name="set_speed">Limit Speed</string>
@@ -32,7 +32,7 @@
     <string name="distance">Distance</string>
     <string name="speed_log">0 km/h</string>
     <string name="distance_log">0 m</string>
-    <string name="stop_requested">Stop Requested</string>
+    <string name="stop_requested">Stop</string>
 
     <!-- About -->
     <string name="about">About</string>


### PR DESCRIPTION
This resolves and closes:
#68 (Requests to Stop)
#86 (Accessibility Requests)

In the passenger screen, there are now Stop and Accessibility request buttons.  They toggle on and off, which displays the relevant request statuses as necessary. 

The boolean data from the toggle buttons get saved as a Shared Preference and is then passed onto the Driver screen, so that drivers are alerted when passengers need to stop, or if they need more  amenities for accessibility if they might be handicapped.