### PR TITLE
[Bug] "/SmartCar/Odometer" is added to "driverDasboard"

### DIFF
--- a/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
+++ b/UI/app/src/main/java/com/example/pathfinder/Activities/DriverDashboard.java
@@ -47,7 +47,7 @@ public class DriverDashboard extends AppCompatActivity implements ThumbstickView
 
     private static final String THROTTLE_CONTROL = "/smartcar/control/speed";
     private static final String STEERING_CONTROL = "/smartcar/control/angle";
-    private static final String ODOMETER = "/smartcar/car/distance";
+    private static final String ODOMETER = "/smartcar/odometer";
     private static final String SPEEDOMETER = "/smartcar/speed";
     private static final String NEXT_STOP = "/smartcar/busNextStop";
     private static final String BUS_STOP_LIST_TOPIC = "/smartcar/bus/StopList";


### PR DESCRIPTION
"Odometer was not measuring the traveled distance"
The topic in driverDashboard is matched as the sketch.

Resolves #94 



Co-authored-by: @bassamEldesouki <bassam.eldesouki.k@gmail.com>